### PR TITLE
Add asymmetric u-net (as in dltk v0.1) and expose activation function

### DIFF
--- a/dltk/core/activations.py
+++ b/dltk/core/activations.py
@@ -25,7 +25,7 @@ def prelu(inputs, alpha_initializer=tf.constant_initializer()):
     return leaky_relu(inputs, alpha)
 
 
-def leaky_relu(inputs, alpha=0.01):
+def leaky_relu(inputs, alpha=0.1):
     """Leaky ReLu activation function
 
     Args:

--- a/dltk/core/residual_unit.py
+++ b/dltk/core/residual_unit.py
@@ -13,6 +13,7 @@ def vanilla_residual_unit_3d(inputs,
                              strides=(1, 1, 1),
                              mode=tf.estimator.ModeKeys.EVAL,
                              use_bias=False,
+                             activation=tf.nn.relu6,
                              kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                              bias_initializer=tf.zeros_initializer(),
                              kernel_regularizer=None,
@@ -35,6 +36,7 @@ def vanilla_residual_unit_3d(inputs,
             convolutions.
         mode (str, optional): One of the tf.estimator.ModeKeys: TRAIN, EVAL or
             PREDICT
+        activation (optional): A function to use as activation function.
         use_bias (bool, optional): Train a bias with each convolution.
         kernel_initializer (TYPE, optional): Initialisation of convolution kernels
         bias_initializer (TYPE, optional): Initialisation of bias
@@ -45,7 +47,6 @@ def vanilla_residual_unit_3d(inputs,
         tf.Tensor: Output of the residual unit
     """
 
-    relu_op = tf.nn.relu6  # or tf.nn.relu
     pool_op = tf.layers.max_pooling3d
 
     conv_params = {'padding': 'same',
@@ -77,7 +78,7 @@ def vanilla_residual_unit_3d(inputs,
 
         x = tf.layers.batch_normalization(
             x, training=mode == tf.estimator.ModeKeys.TRAIN)
-        x = relu_op(x)
+        x = activation(x)
 
         x = tf.layers.conv3d(
             inputs=x,
@@ -89,7 +90,7 @@ def vanilla_residual_unit_3d(inputs,
     with tf.variable_scope('sub_unit1'):
         x = tf.layers.batch_normalization(
             x, training=mode == tf.estimator.ModeKeys.TRAIN)
-        x = relu_op(x)
+        x = activation(x)
 
         x = tf.layers.conv3d(
             inputs=x,

--- a/dltk/networks/autoencoder/convolutional_autoencoder.py
+++ b/dltk/networks/autoencoder/convolutional_autoencoder.py
@@ -12,6 +12,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
                                  strides=((2, 2, 2), (2, 2, 2), (2, 2, 2)),
                                  mode=tf.estimator.ModeKeys.TRAIN,
                                  use_bias=False,
+                                 activation=tf.nn.relu6,
                                  kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                                  bias_initializer=tf.zeros_initializer(),
                                  kernel_regularizer=None,
@@ -35,6 +36,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
         mode (str, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
             EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -55,7 +57,6 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
 
     conv_op = tf.layers.conv3d
     tp_conv_op = tf.layers.conv3d_transpose
-    relu_op = tf.nn.relu6
 
     conv_params = {'padding': 'same',
                    'use_bias': use_bias,
@@ -82,7 +83,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
                 x = tf.layers.batch_normalization(
                     inputs=x,
                     training=mode == tf.estimator.ModeKeys.TRAIN)
-                x = relu_op(x)
+                x = activation(x)
                 tf.logging.info('Encoder at res_scale {} shape: {}'.format(
                     res_scale, x.get_shape()))
 
@@ -102,7 +103,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
 
             x = tf.layers.batch_normalization(
                 x, training=mode == tf.estimator.ModeKeys.TRAIN)
-            x = relu_op(x)
+            x = activation(x)
             tf.logging.info('Encoder at res_scale {} tensor shape: {}'.format(
                 res_scale, x.get_shape()))
 
@@ -124,7 +125,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
 
     x = tf.layers.dense(inputs=x,
                         units=np.prod(x_shape[1:]),
-                        activation=relu_op,
+                        activation=activation,
                         use_bias=conv_params['use_bias'],
                         kernel_initializer=conv_params['kernel_initializer'],
                         bias_initializer=conv_params['bias_initializer'],
@@ -153,7 +154,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
 
             x = tf.layers.batch_normalization(
                 x, training=mode == tf.estimator.ModeKeys.TRAIN)
-            x = relu_op(x)
+            x = activation(x)
             tf.logging.info('Decoder at res_scale {} tensor shape: {}'.format(
                 res_scale, x.get_shape()))
 
@@ -168,7 +169,7 @@ def convolutional_autoencoder_3d(inputs, num_convolutions=1,
 
                 x = tf.layers.batch_normalization(
                     x, training=mode == tf.estimator.ModeKeys.TRAIN)
-                x = relu_op(x)
+                x = activation(x)
             tf.logging.info('Decoder at res_scale {} tensor shape: {}'.format(
                 res_scale, x.get_shape()))
 

--- a/dltk/networks/regression_classification/resnet.py
+++ b/dltk/networks/regression_classification/resnet.py
@@ -15,6 +15,7 @@ def resnet_3d(inputs,
               strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
               mode=tf.estimator.ModeKeys.EVAL,
               use_bias=False,
+              activation=tf.nn.relu6,
               kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
               bias_initializer=tf.zeros_initializer(),
               kernel_regularizer=None, bias_regularizer=None):
@@ -41,6 +42,7 @@ def resnet_3d(inputs,
         mode (TYPE, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
             EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -89,6 +91,7 @@ def resnet_3d(inputs,
                 inputs=x,
                 out_filters=filters[res_scale],
                 strides=strides[res_scale],
+                activation=activation,
                 mode=mode)
         saved_strides.append(strides[res_scale])
 
@@ -100,6 +103,7 @@ def resnet_3d(inputs,
                     inputs=x,
                     out_filters=filters[res_scale],
                     strides=(1, 1, 1),
+                    activation=activation,
                     mode=mode)
         res_scales.append(x)
         tf.logging.info('Encoder at res_scale {} tensor shape: {}'.format(

--- a/dltk/networks/segmentation/fcn.py
+++ b/dltk/networks/segmentation/fcn.py
@@ -14,7 +14,8 @@ def upscore_layer_3d(inputs,
                      out_filters,
                      in_filters=None,
                      strides=(2, 2, 2),
-                     mode=tf.estimator.ModeKeys.EVAL, use_bias=False,
+                     mode=tf.estimator.ModeKeys.EVAL,
+                     use_bias=False,
                      kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                      bias_initializer=tf.zeros_initializer(),
                      kernel_regularizer=None,
@@ -101,6 +102,7 @@ def residual_fcn_3d(inputs,
                     strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
                     mode=tf.estimator.ModeKeys.EVAL,
                     use_bias=False,
+                    activation=tf.nn.relu6,
                     kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                     bias_initializer=tf.zeros_initializer(),
                     kernel_regularizer=None,
@@ -130,6 +132,7 @@ def residual_fcn_3d(inputs,
         mode (TYPE, optional): One of the tf.estimator.ModeKeys strings:
             TRAIN, EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -179,6 +182,7 @@ def residual_fcn_3d(inputs,
                 inputs=x,
                 out_filters=filters[res_scale],
                 strides=strides[res_scale],
+                activation=activation,
                 mode=mode)
         saved_strides.append(strides[res_scale])
 
@@ -190,6 +194,7 @@ def residual_fcn_3d(inputs,
                     inputs=x,
                     out_filters=filters[res_scale],
                     strides=(1, 1, 1),
+                    activation=activation,
                     mode=mode)
         res_scales.append(x)
 

--- a/dltk/networks/segmentation/unet.py
+++ b/dltk/networks/segmentation/unet.py
@@ -43,6 +43,7 @@ def residual_unet_3d(inputs,
                      strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
                      mode=tf.estimator.ModeKeys.EVAL,
                      use_bias=False,
+                     activation=tf.nn.relu6,
                      kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                      bias_initializer=tf.zeros_initializer(),
                      kernel_regularizer=None,
@@ -72,6 +73,7 @@ def residual_unet_3d(inputs,
         mode (TYPE, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
             EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -122,6 +124,7 @@ def residual_unet_3d(inputs,
                 inputs=x,
                 out_filters=filters[res_scale],
                 strides=strides[res_scale],
+                activation=activation,
                 mode=mode)
         saved_strides.append(strides[res_scale])
 
@@ -133,6 +136,7 @@ def residual_unet_3d(inputs,
                     inputs=x,
                     out_filters=filters[res_scale],
                     strides=(1, 1, 1),
+                    activation=activation,
                     mode=mode)
         res_scales.append(x)
 
@@ -197,6 +201,7 @@ def asymmetric_residual_unet_3d(
         strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
         mode=tf.estimator.ModeKeys.EVAL,
         use_bias=False,
+        activation=tf.nn.relu6,
         kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
         bias_initializer=tf.zeros_initializer(),
         kernel_regularizer=None,
@@ -226,6 +231,7 @@ def asymmetric_residual_unet_3d(
         mode (TYPE, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
             EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -276,6 +282,7 @@ def asymmetric_residual_unet_3d(
                 inputs=x,
                 out_filters=filters[res_scale],
                 strides=strides[res_scale],
+                activation=activation,
                 mode=mode)
         saved_strides.append(strides[res_scale])
 
@@ -287,6 +294,7 @@ def asymmetric_residual_unet_3d(
                     inputs=x,
                     out_filters=filters[res_scale],
                     strides=(1, 1, 1),
+                    activation=activation,
                     mode=mode)
         res_scales.append(x)
 
@@ -310,6 +318,7 @@ def asymmetric_residual_unet_3d(
                 inputs=x,
                 out_filters=filters[res_scale],
                 strides=(1, 1, 1),
+                activation=activation,
                 mode=mode)
         tf.logging.info('Decoder at res_scale {} tensor shape: {}'.format(
             res_scale, x.get_shape()))

--- a/dltk/networks/segmentation/unet.py
+++ b/dltk/networks/segmentation/unet.py
@@ -187,3 +187,155 @@ def residual_unet_3d(inputs,
         outputs['y_'] = y_
 
     return outputs
+
+
+def asymmetric_residual_unet_3d(
+        inputs,
+        num_classes,
+        num_res_units=1,
+        filters=(16, 32, 64, 128),
+        strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
+        mode=tf.estimator.ModeKeys.EVAL,
+        use_bias=False,
+        kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
+        bias_initializer=tf.zeros_initializer(),
+        kernel_regularizer=None,
+        bias_regularizer=None):
+    """
+    Image segmentation network based on a flexible UNET architecture [1]
+    using residual units [2] as feature extractors. Downsampling and
+    upsampling of features is done via strided convolutions and transpose
+    convolutions, respectively. On each resolution scale s are
+    num_residual_units with filter size = filters[s]. strides[s] determine
+    the downsampling factor at each resolution scale.
+
+    [1] O. Ronneberger et al. U-Net: Convolutional Networks for Biomedical Image
+        Segmentation. MICCAI 2015.
+    [2] K. He et al. Identity Mappings in Deep Residual Networks. ECCV 2016.
+
+    Args:
+        inputs (tf.Tensor): Input feature tensor to the network (rank 5
+            required).
+        num_classes (int): Number of output classes.
+        num_res_units (int, optional): Number of residual units at each
+            resolution scale.
+        filters (tuple, optional): Number of filters for all residual units at
+            each resolution scale.
+        strides (tuple, optional): Stride of the first unit on a resolution
+            scale.
+        mode (TYPE, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
+            EVAL or PREDICT
+        use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        kernel_initializer (TYPE, optional): An initializer for the convolution
+            kernel.
+        bias_initializer (TYPE, optional): An initializer for the bias vector.
+            If None, no bias will be applied.
+        kernel_regularizer (None, optional): Optional regularizer for the
+            convolution kernel.
+        bias_regularizer (None, optional): Optional regularizer for the bias
+            vector.
+
+    Returns:
+        dict: dictionary of output tensors
+
+    """
+    outputs = {}
+    assert len(strides) == len(filters)
+    assert len(inputs.get_shape().as_list()) == 5, \
+        'inputs are required to have a rank of 5.'
+
+    conv_params = {'padding': 'same',
+                   'use_bias': use_bias,
+                   'kernel_initializer': kernel_initializer,
+                   'bias_initializer': bias_initializer,
+                   'kernel_regularizer': kernel_regularizer,
+                   'bias_regularizer': bias_regularizer}
+
+    x = inputs
+
+    # Initial convolution with filters[0]
+    x = tf.layers.conv3d(inputs=x,
+                         filters=filters[0],
+                         kernel_size=(3, 3, 3),
+                         strides=strides[0],
+                         **conv_params)
+
+    tf.logging.info('Init conv tensor shape {}'.format(x.get_shape()))
+
+    # Residual feature encoding blocks with num_res_units at different
+    # resolution scales res_scales
+    res_scales = [x]
+    saved_strides = []
+    for res_scale in range(1, len(filters)):
+
+        # Features are downsampled via strided convolutions. These are defined
+        # in `strides` and subsequently saved
+        with tf.variable_scope('enc_unit_{}_0'.format(res_scale)):
+
+            x = vanilla_residual_unit_3d(
+                inputs=x,
+                out_filters=filters[res_scale],
+                strides=strides[res_scale],
+                mode=mode)
+        saved_strides.append(strides[res_scale])
+
+        for i in range(1, num_res_units):
+
+            with tf.variable_scope('enc_unit_{}_{}'.format(res_scale, i)):
+
+                x = vanilla_residual_unit_3d(
+                    inputs=x,
+                    out_filters=filters[res_scale],
+                    strides=(1, 1, 1),
+                    mode=mode)
+        res_scales.append(x)
+
+        tf.logging.info('Encoder at res_scale {} tensor shape: {}'.format(
+            res_scale, x.get_shape()))
+
+    # Upsample and concat layers [1] reconstruct the predictions to higher
+    # resolution scales
+    for res_scale in range(len(filters) - 2, -1, -1):
+
+        with tf.variable_scope('up_concat_{}'.format(res_scale)):
+
+            x = upsample_and_concat(
+                inputs=x,
+                inputs2=res_scales[res_scale],
+                strides=saved_strides[res_scale])
+
+        with tf.variable_scope('dec_unit_{}'.format(res_scale)):
+
+            x = vanilla_residual_unit_3d(
+                inputs=x,
+                out_filters=filters[res_scale],
+                strides=(1, 1, 1),
+                mode=mode)
+        tf.logging.info('Decoder at res_scale {} tensor shape: {}'.format(
+            res_scale, x.get_shape()))
+
+    # Last convolution
+    with tf.variable_scope('last'):
+
+        x = tf.layers.conv3d(inputs=x,
+                             filters=num_classes,
+                             kernel_size=(1, 1, 1),
+                             strides=(1, 1, 1),
+                             **conv_params)
+
+    tf.logging.info('Output tensor shape {}'.format(x.get_shape()))
+
+    # Define the outputs
+    outputs['logits'] = x
+
+    with tf.variable_scope('pred'):
+        y_prob = tf.nn.softmax(x)
+        outputs['y_prob'] = y_prob
+
+        y_ = tf.argmax(x, axis=-1) \
+            if num_classes > 1 \
+            else tf.cast(tf.greater_equal(x[..., 0], 0.5), tf.int32)
+
+        outputs['y_'] = y_
+
+    return outputs

--- a/dltk/networks/segmentation/unet.py
+++ b/dltk/networks/segmentation/unet.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 
 from dltk.core.residual_unit import vanilla_residual_unit_3d
 from dltk.core.upsample import linear_upsample_3d
+from dltk.core.activations import leaky_relu
 
 
 def upsample_and_concat(inputs, inputs2, strides=(2, 2, 2)):
@@ -43,7 +44,7 @@ def residual_unet_3d(inputs,
                      strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
                      mode=tf.estimator.ModeKeys.EVAL,
                      use_bias=False,
-                     activation=tf.nn.relu6,
+                     activation=leaky_relu,
                      kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                      bias_initializer=tf.zeros_initializer(),
                      kernel_regularizer=None,
@@ -201,7 +202,7 @@ def asymmetric_residual_unet_3d(
         strides=((1, 1, 1), (2, 2, 2), (2, 2, 2), (2, 2, 2)),
         mode=tf.estimator.ModeKeys.EVAL,
         use_bias=False,
-        activation=tf.nn.relu6,
+        activation=leaky_relu,
         kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
         bias_initializer=tf.zeros_initializer(),
         kernel_regularizer=None,

--- a/dltk/networks/super_resolution/simple_super_resolution.py
+++ b/dltk/networks/super_resolution/simple_super_resolution.py
@@ -11,6 +11,7 @@ def simple_super_resolution_3d(inputs,
                                upsampling_factor=(2, 2, 2),
                                mode=tf.estimator.ModeKeys.EVAL,
                                use_bias=False,
+                               activation=tf.nn.relu6,
                                kernel_initializer=tf.initializers.variance_scaling(distribution='uniform'),
                                bias_initializer=tf.zeros_initializer(),
                                kernel_regularizer=None,
@@ -29,6 +30,7 @@ def simple_super_resolution_3d(inputs,
         mode (TYPE, optional): One of the tf.estimator.ModeKeys strings: TRAIN,
             EVAL or PREDICT
         use_bias (bool, optional): Boolean, whether the layer uses a bias.
+        activation (optional): A function to use as activation function.
         kernel_initializer (TYPE, optional): An initializer for the convolution
             kernel.
         bias_initializer (TYPE, optional): An initializer for the bias vector.
@@ -51,7 +53,6 @@ def simple_super_resolution_3d(inputs,
 
     conv_op = tf.layers.conv3d
     tp_conv_op = tf.layers.conv3d_transpose
-    relu_op = tf.nn.relu6
 
     conv_params = {'padding': 'same',
                    'use_bias': use_bias,
@@ -80,7 +81,7 @@ def simple_super_resolution_3d(inputs,
                 x = tf.layers.batch_normalization(
                     x, training=mode == tf.estimator.ModeKeys.TRAIN)
 
-                x = relu_op(x)
+                x = activation(x)
 
                 tf.logging.info('Encoder at unit_{}_{} tensor '
                                 'shape: {}'.format(unit, i, x.get_shape()))


### PR DESCRIPTION
This PR adds the asymmetric U-Net implementation we used in DLTK v0.1 . Also, it exposes the activation function used within the networks and the residual unit.