### PR TITLE
Add docker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-
+#### Added
+- Docker template for containerisation, with image in [docker hub](https://hub.docker.com/r/dltk/dltk/)
 
 ## [0.2]
 
-### Added 
+### Added
 - download scripts for example data
 - model zoo repo
 - simple super-resolution network
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - unet implementation now has convolutional blocks symmetrically in the encoder and decoder
 - core modularisation based on AbstractModule replaced by tf.layer and tf.estimator
 - core io AbstractReader class now wraps tf.contrib.data.Dataset, replacing v0.1 reader and queuing classes
-- tutorials are now changed to explain how dltk modules can be used with tf 
+- tutorials are now changed to explain how dltk modules can be used with tf
 - improved readme in terms of contributing, installation instructions
 - switched to google docstrings and loose coding style
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,24 @@ If you use DLTK in your work please refer to this citation for the current versi
 If you use any application from the [DLTK Model Zoo](https://github.com/DLTK/models), additionally refer to the respective README.md files in the applications' folder to comply with its authors' instructions on referencing.
 
 ### Installation
-1. Setup a virtual environment and activate it. If you intend to run this on 
+1. Setup a virtual environment and activate it. If you intend to run this on
 machines with different system versions, use the --always-copy flag:
 
    ```shell
    virtualenv -p python3 --always-copy venv_tf
    source venv_tf/bin/activate
    ```
-   
+
 2. Install TensorFlow (>=1.4.0) (preferred: with GPU support) for your system
  as described [here](https://www.tensorflow.org/install/):
-   
+
    ```shell
    pip install tensorflow-gpu>=1.4.0
    ```
-   
+
 3. Install DLTK:
    There are two installation options available: You can simply install dltk as is from pypi via
-   
+
    ```shell
    pip install dltk
    ```
@@ -50,11 +50,11 @@ machines with different system versions, use the --always-copy flag:
 
    ```shell
    cd MY_WORKSPACE_DIRECTORY
-   git clone https://github.com/DLTK/DLTK.git 
+   git clone https://github.com/DLTK/DLTK.git
    cd DLTK
    pip install -e .
    ```
-   This will allow you to modify the actual DLTK source code and import that modified source wherever you need it via ```import dltk```. 
+   This will allow you to modify the actual DLTK source code and import that modified source wherever you need it via ```import dltk```.
 
 
 ### Start playing
@@ -64,9 +64,9 @@ machines with different system versions, use the --always-copy flag:
 
 2. Tutorial notebooks
    In ```examples/tutorials``` you will find tutorial notebooks to better understand on how DLTK interfaces with TensorFlow, how to write custom read functions and how to write your own ```model_fn```.   
-   
+
    To run a notebook, navigate to the DLTK source root folder and open a notebook server on ```MY_PORT``` (default 8888):
-   
+
    ```shell
    cd MY_WORKSPACE_DIRECTORY/DLTK
    jupyter notebook --ip=* --port MY_PORT
@@ -86,28 +86,28 @@ We appreciate any contributions to the DLTK and its Model Zoo. If you have impro
 #### Basic contribution guidelines
 - Python coding style: Like TensorFlow, we loosely adhere to [google coding style](https://google.github.io/styleguide/pyguide.html) and [google docstrings](https://google.github.io/styleguide/pyguide.html#Comments).
 - Entirely new features should be committed to ```dltk/contrib``` before we can sensibly integrate it into the core.
-- Standalone problem-specific applications or (re-)implementations of published methods should be committed to the [DLTK Model Zoo](https://github.com/DLTK/models) repo and provide a README.md file with author/coder contact information. 
+- Standalone problem-specific applications or (re-)implementations of published methods should be committed to the [DLTK Model Zoo](https://github.com/DLTK/models) repo and provide a README.md file with author/coder contact information.
 
 #### Running tests locally
-To run the tests on your machine, you can install the ``tests`` extras by 
-running `pip installe -e '.[tests]'` inside the DLTK root directory. This 
-will install all necessary dependencies for testing. You can then run 
+To run the tests on your machine, you can install the ``tests`` extras by
+running `pip installe -e '.[tests]'` inside the DLTK root directory. This
+will install all necessary dependencies for testing. You can then run
 `pytest --cov dltk --flake8 --cov-append` to see whether your code passes.
- 
+
 #### Building docs locally
-To run the tests on your machine, you can install the ``docs`` extras by 
-running `pip installe -e '.[docs]'` inside the DLTK root directory. This 
-will install all necessary dependencies for the documentation. You can then run 
-`make -C docs html` to build the documentation. You can access this 
-documentation in a webbrowser of your choice by pointing it at 
+To run the tests on your machine, you can install the ``docs`` extras by
+running `pip installe -e '.[docs]'` inside the DLTK root directory. This
+will install all necessary dependencies for the documentation. You can then run
+`make -C docs html` to build the documentation. You can access this
+documentation in a webbrowser of your choice by pointing it at
 `docs/build/html/index.html`.
- 
+
 ### The team
-DLTK is currently maintained by [@pawni](https://github.com/pawni) and [@mrajchl](https://github.com/mrajchl) with greatly appreciated contributions coming from individual researchers and engineers listed here in alphabetical order: 
-[@CarloBiffi](https://github.com/CarloBiffi) [@ericspod](https://github.com/ericspod) [@ghisvail](https://github.com/ghisvail) [@mauinz](https://github.com/mauinz) [@michaeld123](https://github.com/michaeld123) [@sk1712](https://github.com/sk1712)
+DLTK is currently maintained by [@pawni](https://github.com/pawni) and [@mrajchl](https://github.com/mrajchl) with greatly appreciated contributions coming from individual researchers and engineers listed here in alphabetical order:
+[@CarloBiffi](https://github.com/CarloBiffi) [@ericspod](https://github.com/ericspod) [@ghisvail](https://github.com/ghisvail) [@mauinz](https://github.com/mauinz) [@mdjaere](https://github.com/mdjaere) [@michaeld123](https://github.com/michaeld123) [@sk1712](https://github.com/sk1712)
 
 ### License
 See [LICENSE](https://github.com/DLTK/DLTK/blob/master/LICENSE)
 
 ### Acknowledgments
-We would like to thank [NVIDIA GPU Computing](http://www.nvidia.com/) for providing us with hardware for our research. 
+We would like to thank [NVIDIA GPU Computing](http://www.nvidia.com/) for providing us with hardware for our research.

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Base image from https://hub.docker.com/r/tensorflow/tensorflow/tags/
+FROM tensorflow/tensorflow:1.4.0-py3
+# Move tensorflow tutorials into its own folder
+RUN mv /notebooks /tensorflow-tutorials && mkdir /notebooks && mv /tensorflow-tutorials /notebooks
+# Get DLTK master from github
+RUN curl -LOk https://github.com/DLTK/DLTK/archive/master.tar.gz && tar xzf master.tar.gz && mv DLTK-master /opt/DLTK && rm master.tar.gz
+WORKDIR /opt/DLTK
+# Install DLTK from source
+RUN pip install --no-cache-dir -e .
+# Copy DLTK tutorials into notebook folder
+RUN cp -r ./examples/tutorials /notebooks/DLTK-tutorials && cp -r ./data /data
+# TensorBoard
+EXPOSE 6006
+# IPython
+EXPOSE 8888
+WORKDIR "/notebooks"
+CMD ["/run_jupyter.sh", "--allow-root"]

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,17 +1,32 @@
 # Base image from https://hub.docker.com/r/tensorflow/tensorflow/tags/
 FROM tensorflow/tensorflow:1.4.0-py3
-# Move tensorflow tutorials into its own folder
-RUN mv /notebooks /tensorflow-tutorials && mkdir /notebooks && mv /tensorflow-tutorials /notebooks
-# Get DLTK master from github
-RUN curl -LOk https://github.com/DLTK/DLTK/archive/master.tar.gz && tar xzf master.tar.gz && mv DLTK-master /opt/DLTK && rm master.tar.gz
-WORKDIR /opt/DLTK
-# Install DLTK from source
-RUN pip install --no-cache-dir -e .
+
+LABEL maintainer="Martin D. Jaere <martin.jaere11@imperial.ac.uk>"
+
+# Move tensorflow tutorials into folder
+RUN mv /notebooks /tensorflow-tutorials && \
+    mkdir /notebooks && \
+    mv /tensorflow-tutorials /notebooks
+
+# Pull master branch from github
+RUN curl -LOk https://github.com/DLTK/DLTK/archive/master.tar.gz && \
+    tar xzf master.tar.gz && \
+    mv DLTK-master /opt/DLTK && \
+    rm master.tar.gz
+
+# Install from source
+RUN pip install --no-cache-dir -e /opt/DLTK
+
 # Copy DLTK tutorials into notebook folder
-RUN cp -r ./examples/tutorials /notebooks/DLTK-tutorials && cp -r ./data /data
+RUN cp -r /opt/DLTK/examples/tutorials /notebooks/DLTK-tutorials
+
 # TensorBoard
 EXPOSE 6006
+
 # IPython
 EXPOSE 8888
-WORKDIR "/notebooks"
-CMD ["/run_jupyter.sh", "--allow-root"]
+WORKDIR /notebooks
+
+# Copy dl instruction files into mounted /data to allow for data persistense
+# Run notebook
+CMD cp -r -n /opt/DLTK/data/* /data && /run_jupyter.sh --allow-root

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -35,4 +35,4 @@ Tip: You can change tensorflow version by editing the Dockerfile base image tag 
 #### CUDA/GPU SUPPORT
 Prerequisites: [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)
 
-Change the Dockerfile base image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/. Build the image, and run docker with `--runtime=nvidia`. See https://github.com/NVIDIA/nvidia-docker for more info.
+To add GPU support, edit the Dockerfile base image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/. Rebuild the image, and run with `docker run --runtime=nvidia …`. See https://github.com/NVIDIA/nvidia-docker for more info.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,6 +1,6 @@
 # Docker support
 
-A simple implementation of docker. The Dockerfile will build an docker image based on tensorflow 1.4.0-py3, or whichever is stated in the Dockerfile. By default it will start a Jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), keep your data folder persistent, see below.
+A simple implementation of docker. By default the Dockerfile will build a docker image based on tensorflow 1.4.0-py3, and start a Jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), make sure you keep your data folder persistent, see below.
 
 ### Intructions
 Prerequisites: docker
@@ -18,15 +18,17 @@ No data or notebooks will be persistent.
 #### Run notebook with persistent data
 `docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 tensorflow-dltk`
 
-You data will be available from /data.
+You data will be available from /data. Notebooks will not be persistent.
 
 #### Run notebook with persistent data and notebooks
 `docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
 
-You data will be available from /data, and notebooks available in the Jupyter Notebook home page.
+You data will be available from /data, and notebooks available from the Jupyter Notebook home page.
 
 #### Run bash
 `docker run --rm -it tensorflow-dltk bash`
+
+See [Docker documenation](https://docs.docker.com/) for more options.
 
 #### CUDA/GPU SUPPORT
 Prerequisites: nvidia-docker

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,33 @@
+# Docker support
+
+A simple implementation of docker. The Dockerfile will build an docker image based on tensorflow 1.4.0-py3, or whichever is stated in the Dockerfile. By default it will start a jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), keep your data folder persistent, see below.
+
+### Intructions
+Prerequisites: docker
+
+#### Build image
+From tools/docker, run
+`docker build -t tensorflow-dltk .`
+
+#### Run notebook
+`docker run --rm -it -p 8888:8888 tensorflow-dltk`
+Nb. No data or notebooks will be persistent
+
+#### Run notebook with persistent data
+`docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 tensorflow-dltk`
+You data will be mounted at /data.
+
+#### Run notebook with persistent data and notebooks
+`docker run --rm -it -v /path/to/data:/data  -v /path/to/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
+
+#### Run bash
+`docker run --rm -it tensorflow-dltk bash`
+
+#### CUDA/GPU SUPPORT
+Prerequisites: nvidia-docker
+
+Change base image tag in Dockerfile to a gpu tag from https://hub.docker.com/r/tensorflow/tensorflow/tags/
+Rebuild the image, and run any of the above examples, but change `docker` to `nvidia-docker`.
+
+#### Examples
+Non-official example images can be found at https://hub.docker.com/r/mdjaere/tensorflow-dltk/

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,6 +1,6 @@
 # Docker support
 
-A simple implementation of docker. The Dockerfile will build an docker image based on tensorflow 1.4.0-py3, or whichever is stated in the Dockerfile. By default it will start a jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), keep your data folder persistent, see below.
+A simple implementation of docker. The Dockerfile will build an docker image based on tensorflow 1.4.0-py3, or whichever is stated in the Dockerfile. By default it will start a Jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), keep your data folder persistent, see below.
 
 ### Intructions
 Prerequisites: docker
@@ -13,17 +13,17 @@ From tools/docker, run
 #### Run notebook
 `docker run --rm -it -p 8888:8888 tensorflow-dltk`
 
-Note that no data or notebooks will be persistent
+No data or notebooks will be persistent.
 
 #### Run notebook with persistent data
 `docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 tensorflow-dltk`
 
-You data will be mounted at /data.
+You data will be available from /data.
 
 #### Run notebook with persistent data and notebooks
 `docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
 
-You data will be mounted at /data, and notebooks will be available in the Jupyter Notebook.
+You data will be available from /data, and notebooks available in the Jupyter Notebook home page.
 
 #### Run bash
 `docker run --rm -it tensorflow-dltk bash`
@@ -31,8 +31,7 @@ You data will be mounted at /data, and notebooks will be available in the Jupyte
 #### CUDA/GPU SUPPORT
 Prerequisites: nvidia-docker
 
-In Dockerfile, change the FROM image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/
-Rebuild the image, and run by using `nvidia-docker` instaed of `docker` with any of the examples above.
+In the Dockerfile, change the base image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/. Rebuild the image, and run by using `nvidia-docker` instead of `docker` with any of the examples above.
 
 #### Examples
 Non-official example images can be found at https://hub.docker.com/r/mdjaere/tensorflow-dltk/

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -7,18 +7,23 @@ Prerequisites: docker
 
 #### Build image
 From tools/docker, run
+
 `docker build -t tensorflow-dltk .`
 
 #### Run notebook
 `docker run --rm -it -p 8888:8888 tensorflow-dltk`
-Nb. No data or notebooks will be persistent
+
+Note that no data or notebooks will be persistent
 
 #### Run notebook with persistent data
 `docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 tensorflow-dltk`
+
 You data will be mounted at /data.
 
 #### Run notebook with persistent data and notebooks
-`docker run --rm -it -v /path/to/data:/data  -v /path/to/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
+`docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
+
+You data will be mounted at /data, and notebooks will be available in the Jupyter Notebook.
 
 #### Run bash
 `docker run --rm -it tensorflow-dltk bash`
@@ -26,8 +31,8 @@ You data will be mounted at /data.
 #### CUDA/GPU SUPPORT
 Prerequisites: nvidia-docker
 
-Change base image tag in Dockerfile to a gpu tag from https://hub.docker.com/r/tensorflow/tensorflow/tags/
-Rebuild the image, and run any of the above examples, but change `docker` to `nvidia-docker`.
+In Dockerfile, change the FROM image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/
+Rebuild the image, and run by using `nvidia-docker` instaed of `docker` with any of the examples above.
 
 #### Examples
 Non-official example images can be found at https://hub.docker.com/r/mdjaere/tensorflow-dltk/

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,39 +1,40 @@
-# Docker support
+# DLTK Docker
 
-A simple implementation of docker. By default the Dockerfile will build a docker image based on tensorflow 1.4.0-py3, and start a Jupyter notebook with tensorflow and DLTK tutorials available. To avoid downloading DLTK example data multiple times (70GB+), make sure you keep your data folder persistent, see below.
+Docker image with DLTK and tensorflow, and Jupyter Notebook tutorials. To avoid re-downloading DLTK example data(70GB+), make sure to keep the data folder persistent, see below. For more info, see [Docker documenation](https://docs.docker.com/).
 
 ### Intructions
-Prerequisites: docker
+Prerequisites: [docker](https://www.docker.com/)
 
-#### Build image
-From tools/docker, run
+#### Pull image
+`docker pull dltk/dltk`
 
-`docker build -t tensorflow-dltk .`
-
-#### Run notebook
-`docker run --rm -it -p 8888:8888 tensorflow-dltk`
+#### Run Notebook
+`docker run --rm -it -p 8888:8888 dltk/dltk`
 
 No data or notebooks will be persistent.
 
-#### Run notebook with persistent data
-`docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 tensorflow-dltk`
+#### Run Notebook with persistent data
+`docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 dltk/dltk`
 
-You data will be available from /data. Notebooks will not be persistent.
+You persistent data is available at `/data`. Notebooks will not be persistent.
 
-#### Run notebook with persistent data and notebooks
-`docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 tensorflow-dltk`
+#### Run Notebook with persistent data and notebooks
+`docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 dltk/dltk`
 
-You data will be available from /data, and notebooks available from the Jupyter Notebook home page.
+You persistent data is available at `/data`. Your own notebooks will be persistent. Tutorials will not be persisent.
+
+#### Note: Setting Notebook password
+By default Jupyter Notebook will create access token for login. To set a password, set environment variable `PASSWORD` at container deployment, for example run docker with `-e PASSWORD=password1234`.
 
 #### Run bash
-`docker run --rm -it tensorflow-dltk bash`
+`docker run --rm -it dltk/dltk bash`
 
-See [Docker documenation](https://docs.docker.com/) for more options.
+#### Build image from Dockerfile
+From folder `tools/docker`, run `docker build -t dltk/dltk:yourbuildtag .` Run with `docker run --rm -it dltk/dltk:yourbuildtag`.
+
+Tip: Change tensorflow version by editing the Dockerfile base image tag to one from https://hub.docker.com/r/tensorflow/tensorflow/tags/ (includes release candidates, nightlies, gpu, etc).
 
 #### CUDA/GPU SUPPORT
-Prerequisites: nvidia-docker
+Prerequisites: [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)
 
-In the Dockerfile, change the base image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/. Rebuild the image, and run by using `nvidia-docker` instead of `docker` with any of the examples above.
-
-#### Examples
-Non-official example images can be found at https://hub.docker.com/r/mdjaere/tensorflow-dltk/
+Change the Dockerfile base image to one of the gpu tagged images from https://hub.docker.com/r/tensorflow/tensorflow/tags/. Build the image, and run docker with `--runtime=nvidia`. See https://github.com/NVIDIA/nvidia-docker for more info.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,6 +1,6 @@
 # DLTK Docker
 
-Docker image with DLTK and tensorflow, and Jupyter Notebook tutorials. To avoid re-downloading DLTK example data(70GB+), make sure to keep the data folder persistent, see below. For more info, see [Docker documenation](https://docs.docker.com/).
+Docker image with DLTK and tensorflow, and Jupyter Notebook tutorials. To avoid downloading the DLTK example data multiple times (70GB+), make sure to keep it persistent, see below. For more info, see [Docker documenation](https://docs.docker.com/).
 
 ### Intructions
 Prerequisites: [docker](https://www.docker.com/)
@@ -13,18 +13,16 @@ Prerequisites: [docker](https://www.docker.com/)
 
 No data or notebooks will be persistent.
 
-#### Run Notebook with persistent data
+#### Run Notebook with persistent DLTK data
 `docker run --rm -it -v /path/to/DTLK/data:/data -p 8888:8888 dltk/dltk`
 
-You persistent data is available at `/data`. Notebooks will not be persistent.
-
 #### Run Notebook with persistent data and notebooks
-`docker run --rm -it -v /path/to/mydata:/data  -v /path/to/own/notebooks:/notebooks/your-notebook-folder-name  -p 8888:8888 dltk/dltk`
+`docker run --rm -it -v /path/to/own/notebook/folder:/notebooks/your-notebook-folder -p 8888:8888 dltk/dltk`
 
-You persistent data is available at `/data`. Your own notebooks will be persistent. Tutorials will not be persisent.
+Notebooks and data in your notebook folder will be persistent. Tutorials will not be persistent.
 
 #### Note: Setting Notebook password
-By default Jupyter Notebook will create access token for login. To set a password, set environment variable `PASSWORD` at container deployment, for example run docker with `-e PASSWORD=password1234`.
+By default Jupyter Notebook will create access token for login. To set a password, set environment variable `PASSWORD` at container deployment, for example `docker run -e PASSWORD=password1234 …`.
 
 #### Run bash
 `docker run --rm -it dltk/dltk bash`
@@ -32,7 +30,7 @@ By default Jupyter Notebook will create access token for login. To set a passwor
 #### Build image from Dockerfile
 From folder `tools/docker`, run `docker build -t dltk/dltk:yourbuildtag .` Run with `docker run --rm -it dltk/dltk:yourbuildtag`.
 
-Tip: Change tensorflow version by editing the Dockerfile base image tag to one from https://hub.docker.com/r/tensorflow/tensorflow/tags/ (includes release candidates, nightlies, gpu, etc).
+Tip: You can change tensorflow version by editing the Dockerfile base image tag to one from https://hub.docker.com/r/tensorflow/tensorflow/tags/, which includes release candidates, nightlies, gpu, etc. NB. DLTK is not guaranteed to run with all versions.
 
 #### CUDA/GPU SUPPORT
 Prerequisites: [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)


### PR DESCRIPTION
Hi everyone,

As discussed on https://gitter.im/DLTK/DLTK: Here's a simple docker implementation built on tensorflow's image from https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker. It enables DLTK to be available in a pre-built, sandboxed and easy to use environment.

Let me know what you think.

Many thanks,
Martin DJ