### PR TITLE
update 'abstract_reader.py' to work on Python3.7

### DIFF
--- a/dltk/io/abstract_reader.py
+++ b/dltk/io/abstract_reader.py
@@ -119,7 +119,7 @@ class Reader(object):
                         ex = clean_ex(ex, self.dtypes)
                         yield ex
                     except (tf.errors.OutOfRangeError, StopIteration):
-                        raise
+                        return
                     except Exception as e:
                         print('got error `{} from `_read_sample`:'.format(e))
                         print(traceback.format_exc())


### PR DESCRIPTION
Line 126: switch 'raise' to 'return' to continue functionality across Python 3.7 as well.